### PR TITLE
KP-911 Fix recursive deletion

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,7 +10,7 @@ const {
 const {
   assertPathExistence,
   listDirectoryRecursively,
-} = require("./fs-helpers");
+} = require("./helpers");
 
 async function createBucket(params) {
   const {

--- a/helpers.js
+++ b/helpers.js
@@ -1,4 +1,4 @@
-const { join } = require("path");
+const { join, dirname } = require("path");
 const fs = require("fs");
 const { stat, readdir } = require("fs/promises");
 
@@ -28,7 +28,17 @@ async function listDirectoryRecursively(directoryPath) {
   return recursiveDirectoryFiles.flat();
 }
 
+function getAllDirectoriesInPath(path) {
+  const directoryPath = dirname(path);
+  if (directoryPath === "." || directoryPath === "/") {
+    return [`${path}/`];
+  }
+
+  return [...getAllDirectoriesInPath(directoryPath), `${path}/`];
+}
+
 module.exports = {
   assertPathExistence,
   listDirectoryRecursively,
+  getAllDirectoriesInPath,
 };

--- a/helpers.js
+++ b/helpers.js
@@ -28,17 +28,17 @@ async function listDirectoryRecursively(directoryPath) {
   return recursiveDirectoryFiles.flat();
 }
 
-function getAllDirectoriesInPath(path) {
+function walkThroughParentDirectories(path) {
   const directoryPath = dirname(path);
   if (directoryPath === "." || directoryPath === "/") {
     return [`${path}/`];
   }
 
-  return [...getAllDirectoriesInPath(directoryPath), `${path}/`];
+  return [...walkThroughParentDirectories(directoryPath), `${path}/`];
 }
 
 module.exports = {
   assertPathExistence,
   listDirectoryRecursively,
-  getAllDirectoriesInPath,
+  walkThroughParentDirectories,
 };


### PR DESCRIPTION
[**KP-911 in Jira**](https://kaholo.atlassian.net/browse/KP-911)

`@google-cloud/storage` package does not have a method to fetch _directories_, so what the plugin does is it fetches all files and then extracts all _directory_ paths, e.g.:
* **fetched file**: `dir1/dir2/file1.txt`
* **extracted _directory_ paths**: `dir1/dir2/`, `dir1/`